### PR TITLE
verify scroll controller is attached before scrolling

### DIFF
--- a/lib/src/indicator.dart
+++ b/lib/src/indicator.dart
@@ -84,16 +84,20 @@ class _PageViewDotIndicatorState extends State<PageViewDotIndicator> {
 
   @override
   void initState() {
+    super.initState();
     _scrollController = ScrollController();
     SchedulerBinding.instance.addPostFrameCallback((_) {
-      scrollToCurrentPosition();
+      if (_scrollController.hasClients) {
+        scrollToCurrentPosition();
+      }
     });
-    super.initState();
   }
 
   @override
   void didUpdateWidget(covariant PageViewDotIndicator oldWidget) {
-    scrollToCurrentPosition();
+    if (_scrollController.hasClients) {
+      scrollToCurrentPosition();
+    }
     super.didUpdateWidget(oldWidget);
   }
 


### PR DESCRIPTION
This PR attempts to fix errors mentioned in #12 .This crash is being caused by the ScrollController not being attached to a Scrollable yet, then being asked for position. It's possible that somehow the ScrollController is being referenced post detach from a Scrollable.