### PR TITLE
Allow text inside each indicator, change list axis and make list scrollable

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -37,29 +37,66 @@ class _MyAppState extends State<MyApp> {
       home: Scaffold(
         backgroundColor: Colors.white,
         body: SafeArea(
-          child: Column(
+          child: Row(
             children: [
               Expanded(
-                child: PageView(
-                  controller: _pageController,
-                  onPageChanged: (page) {
-                    setState(() {
-                      selectedPage = page;
-                    });
-                  },
-                  children: List.generate(pageCount, (index) {
-                    return Center(
-                      child: Text('Page $index'),
-                    );
-                  }),
+                child: Column(
+                  children: [
+                    Expanded(
+                      child: PageView(
+                        controller: _pageController,
+                        onPageChanged: (page) {
+                          setState(() {
+                            selectedPage = page;
+                          });
+                        },
+                        children: List.generate(pageCount, (index) {
+                          return Center(
+                            child: Text('Page $index'),
+                          );
+                        }),
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 24),
+                      child: PageViewDotIndicator(
+                        currentItem: selectedPage,
+                        count: pageCount,
+                        unselectedColor: Colors.yellow,
+                        selectedColor: Colors.blue,
+                        duration: const Duration(milliseconds: 200),
+                        boxShape: BoxShape.rectangle,
+                        onItemClicked: (index) {
+                          _pageController.animateToPage(
+                            index,
+                            duration: const Duration(milliseconds: 200),
+                            curve: Curves.easeInOut,
+                          );
+                        },
+                        childText: (index) => "Item ${index}",
+                        size: Size(50, 50),
+                        unselectedSize: Size(50, 50),
+                        childTextStyle: (index) => TextStyle(
+                          color: selectedPage == index ? Colors.red : Colors.green,
+                        ),
+                        borderRadius: BorderRadius.circular(50),
+                        padding: EdgeInsets.all(16),
+                        scrollable: true,
+                      ),
+                    ),
+                    const SizedBox(
+                      height: 16,
+                    ),
+                  ],
                 ),
               ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 24),
+              SizedBox(
+                width: 100,
+                height: double.maxFinite,
                 child: PageViewDotIndicator(
                   currentItem: selectedPage,
                   count: pageCount,
-                  unselectedColor: Colors.transparent,
+                  unselectedColor: Colors.yellow,
                   selectedColor: Colors.blue,
                   duration: const Duration(milliseconds: 200),
                   boxShape: BoxShape.rectangle,
@@ -74,18 +111,17 @@ class _MyAppState extends State<MyApp> {
                   size: Size(50, 50),
                   unselectedSize: Size(50, 50),
                   childTextStyle: (index) => TextStyle(
-                      color: selectedPage == index ? Colors.red : Colors.green,
-                    ),
+                    color: selectedPage == index ? Colors.red : Colors.green,
+                  ),
                   borderRadius: BorderRadius.circular(50),
                   padding: EdgeInsets.all(16),
                   scrollable: true,
+                  direction: Axis.vertical,
+                  margin: EdgeInsets.symmetric(vertical: 8),
                 ),
-              ),
-              const SizedBox(
-                height: 16,
-              ),
+              )
             ],
-          ),
+          )
         ),
       ),
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -76,6 +76,8 @@ class _MyAppState extends State<MyApp> {
                   childTextStyle: (index) => TextStyle(
                       color: selectedPage == index ? Colors.red : Colors.green,
                     ),
+                  borderRadius: BorderRadius.circular(50),
+                  padding: EdgeInsets.all(4),
                 ),
               ),
               const SizedBox(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -78,6 +78,7 @@ class _MyAppState extends State<MyApp> {
                     ),
                   borderRadius: BorderRadius.circular(50),
                   padding: EdgeInsets.all(4),
+                  scrollable: true,
                 ),
               ),
               const SizedBox(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -59,7 +59,7 @@ class _MyAppState extends State<MyApp> {
                 child: PageViewDotIndicator(
                   currentItem: selectedPage,
                   count: pageCount,
-                  unselectedColor: Colors.black26,
+                  unselectedColor: Colors.transparent,
                   selectedColor: Colors.blue,
                   duration: const Duration(milliseconds: 200),
                   boxShape: BoxShape.rectangle,
@@ -74,7 +74,8 @@ class _MyAppState extends State<MyApp> {
                   size: Size(50, 30),
                   unselectedSize: Size(50, 30),
                   childTextStyle: (index) => TextStyle(
-                      color: selectedPage == index ? Colors.red : Colors.green),
+                      color: selectedPage == index ? Colors.red : Colors.green,
+                    ),
                 ),
               ),
               const SizedBox(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -70,6 +70,11 @@ class _MyAppState extends State<MyApp> {
                       curve: Curves.easeInOut,
                     );
                   },
+                  childText: (index) => "Item ${index}",
+                  size: Size(50, 30),
+                  unselectedSize: Size(50, 30),
+                  childTextStyle: (index) => TextStyle(
+                      color: selectedPage == index ? Colors.red : Colors.green),
                 ),
               ),
               const SizedBox(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -26,7 +26,7 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
-    const pageCount = 5;
+    const pageCount = 40;
 
     return MaterialApp(
       title: 'Page view dot indicator',
@@ -71,13 +71,13 @@ class _MyAppState extends State<MyApp> {
                     );
                   },
                   childText: (index) => "Item ${index}",
-                  size: Size(50, 30),
-                  unselectedSize: Size(50, 30),
+                  size: Size(50, 50),
+                  unselectedSize: Size(50, 50),
                   childTextStyle: (index) => TextStyle(
                       color: selectedPage == index ? Colors.red : Colors.green,
                     ),
                   borderRadius: BorderRadius.circular(50),
-                  padding: EdgeInsets.all(4),
+                  padding: EdgeInsets.all(16),
                   scrollable: true,
                 ),
               ),

--- a/lib/src/indicator.dart
+++ b/lib/src/indicator.dart
@@ -170,37 +170,43 @@ class _PageViewDotIndicatorState extends State<PageViewDotIndicator> {
           itemBuilder: (context, index) {
             return Padding(
               padding: widget.margin,
-              child: InkWell(
-                onTap: () => widget.onItemClicked?.call(index),
-                child: AnimatedContainer(
-                  duration: widget.duration,
-                  decoration: BoxDecoration(
-                    borderRadius: widget.borderRadius,
-                    shape: widget.boxShape,
-                    color: index == widget.currentItem
-                        ? widget.selectedColor
-                        : widget.unselectedColor,
+              child: ClipRRect(
+                borderRadius: widget.borderRadius ?? BorderRadius.circular(0),
+                child: Material(
+                  color: Colors.transparent,
+                  child: InkWell(
+                    onTap: () => widget.onItemClicked?.call(index),
+                    child: AnimatedContainer(
+                      duration: widget.duration,
+                      decoration: BoxDecoration(
+                        borderRadius: widget.borderRadius,
+                        shape: widget.boxShape,
+                        color: index == widget.currentItem
+                            ? widget.selectedColor
+                            : widget.unselectedColor,
+                      ),
+                      width: index == widget.currentItem
+                          ? widget.size.width
+                          : widget.unselectedSize.width,
+                      height: index == widget.currentItem
+                          ? widget.size.height
+                          : widget.unselectedSize.height,
+                      child: widget.childText != null
+                          ? Center(
+                              child: AnimatedDefaultTextStyle(
+                                duration: widget.duration,
+                                curve: Curves.easeIn,
+                                style: widget.childTextStyle != null
+                                    ? widget.childTextStyle!(index)
+                                    : const TextStyle(),
+                                child: Text(
+                                  widget.childText!(index),
+                                ),
+                              ),
+                            )
+                          : null,
+                    ),
                   ),
-                  width: index == widget.currentItem
-                      ? widget.size.width
-                      : widget.unselectedSize.width,
-                  height: index == widget.currentItem
-                      ? widget.size.height
-                      : widget.unselectedSize.height,
-                  child: widget.childText != null
-                      ? Center(
-                          child: AnimatedDefaultTextStyle(
-                            duration: widget.duration,
-                            curve: Curves.easeIn,
-                            style: widget.childTextStyle != null
-                                ? widget.childTextStyle!(index)
-                                : const TextStyle(),
-                            child: Text(
-                              widget.childText!(index),
-                            ),
-                          ),
-                        )
-                      : null,
                 ),
               ),
             );

--- a/lib/src/indicator.dart
+++ b/lib/src/indicator.dart
@@ -35,6 +35,7 @@ class PageViewDotIndicator extends StatefulWidget {
     this.childText,
     this.childTextStyle,
     this.scrollable,
+    this.direction = Axis.horizontal
   })  : assert(
           currentItem >= 0 && currentItem < count,
           'Current item must be within the range of items. Make sure you are using 0-based indexing',
@@ -102,6 +103,9 @@ class PageViewDotIndicator extends StatefulWidget {
 
   /// Makes the list scrollable
   final bool? scrollable;
+
+  /// Change the scroll direction
+  final Axis direction;
 
   @override
   State<PageViewDotIndicator> createState() => _PageViewDotIndicatorState();
@@ -176,7 +180,7 @@ class _PageViewDotIndicatorState extends State<PageViewDotIndicator> {
           itemCount: widget.count,
           controller: _scrollController,
           shrinkWrap: !_needsScrolling(),
-          scrollDirection: Axis.horizontal,
+          scrollDirection: widget.direction,
           clipBehavior: Clip.antiAlias,
           itemBuilder: (context, index) {
             return Padding(

--- a/lib/src/indicator.dart
+++ b/lib/src/indicator.dart
@@ -34,6 +34,7 @@ class PageViewDotIndicator extends StatefulWidget {
     this.onItemClicked,
     this.childText,
     this.childTextStyle,
+    this.scrollable,
   })  : assert(
           currentItem >= 0 && currentItem < count,
           'Current item must be within the range of items. Make sure you are using 0-based indexing',
@@ -99,6 +100,9 @@ class PageViewDotIndicator extends StatefulWidget {
   /// Styles the [childText]
   final TextStyle Function(int index)? childTextStyle;
 
+  /// Makes the list scrollable
+  final bool? scrollable;
+
   @override
   State<PageViewDotIndicator> createState() => _PageViewDotIndicatorState();
 }
@@ -161,7 +165,7 @@ class _PageViewDotIndicatorState extends State<PageViewDotIndicator> {
         height: widget.size.height,
         child: ListView.builder(
           padding: widget.padding,
-          physics: const NeverScrollableScrollPhysics(),
+          physics: widget.scrollable == null || widget.scrollable == false ? const NeverScrollableScrollPhysics() : null,
           itemCount: widget.count,
           controller: _scrollController,
           shrinkWrap: !_needsScrolling(),

--- a/lib/src/indicator.dart
+++ b/lib/src/indicator.dart
@@ -130,14 +130,14 @@ class _PageViewDotIndicatorState extends State<PageViewDotIndicator> {
   }
 
   void scrollToCurrentPosition() {
-    final last10perc = (widget.count*0.1).ceil();
-    final widgetOffset = widget.currentItem > last10perc 
-      ? _getOffsetForCurrentPosition() + widget.size.width
-      : _getOffsetForCurrentPosition();
+    final last10perc = (widget.count * 0.1).ceil();
+    final widgetOffset = widget.currentItem > last10perc
+        ? _getOffsetForCurrentPosition() + widget.size.width
+        : _getOffsetForCurrentPosition();
     _scrollController.animateTo(
       widgetOffset > _scrollController.position.maxScrollExtent
-        ? _scrollController.position.maxScrollExtent
-        : widgetOffset,
+          ? _scrollController.position.maxScrollExtent
+          : widgetOffset,
       duration: const Duration(milliseconds: 200),
       curve: Curves.easeIn,
     );
@@ -170,7 +170,9 @@ class _PageViewDotIndicatorState extends State<PageViewDotIndicator> {
         height: widget.size.height,
         child: ListView.builder(
           padding: widget.padding,
-          physics: widget.scrollable == null || widget.scrollable == false ? const NeverScrollableScrollPhysics() : null,
+          physics: widget.scrollable == null || widget.scrollable == false
+              ? const NeverScrollableScrollPhysics()
+              : null,
           itemCount: widget.count,
           controller: _scrollController,
           shrinkWrap: !_needsScrolling(),

--- a/lib/src/indicator.dart
+++ b/lib/src/indicator.dart
@@ -227,7 +227,9 @@ class _PageViewDotIndicatorState extends State<PageViewDotIndicator> {
     final offsetPerPosition =
         _scrollController.position.maxScrollExtent / widget.count;
     final widgetOffset = widget.currentItem * offsetPerPosition;
-    return widgetOffset;
+    return widgetOffset > _scrollController.position.maxScrollExtent
+      ? _scrollController.position.maxScrollExtent
+      : widgetOffset;
   }
 
   /// This is important to center the list items if they fit on screen by making

--- a/lib/src/indicator.dart
+++ b/lib/src/indicator.dart
@@ -135,7 +135,9 @@ class _PageViewDotIndicatorState extends State<PageViewDotIndicator> {
       ? _getOffsetForCurrentPosition() + widget.size.width
       : _getOffsetForCurrentPosition();
     _scrollController.animateTo(
-      widgetOffset,
+      widgetOffset > _scrollController.position.maxScrollExtent
+        ? _scrollController.position.maxScrollExtent
+        : widgetOffset,
       duration: const Duration(milliseconds: 200),
       curve: Curves.easeIn,
     );
@@ -227,9 +229,7 @@ class _PageViewDotIndicatorState extends State<PageViewDotIndicator> {
     final offsetPerPosition =
         _scrollController.position.maxScrollExtent / widget.count;
     final widgetOffset = widget.currentItem * offsetPerPosition;
-    return widgetOffset > _scrollController.position.maxScrollExtent
-      ? _scrollController.position.maxScrollExtent
-      : widgetOffset;
+    return widgetOffset;
   }
 
   /// This is important to center the list items if they fit on screen by making

--- a/lib/src/indicator.dart
+++ b/lib/src/indicator.dart
@@ -32,6 +32,8 @@ class PageViewDotIndicator extends StatefulWidget {
     this.boxShape = BoxShape.circle,
     this.borderRadius,
     this.onItemClicked,
+    this.childText,
+    this.childTextStyle,
   })  : assert(
           currentItem >= 0 && currentItem < count,
           'Current item must be within the range of items. Make sure you are using 0-based indexing',
@@ -91,6 +93,12 @@ class PageViewDotIndicator extends StatefulWidget {
   /// Callback called when item is clicked.
   final void Function(int index)? onItemClicked;
 
+  /// Adds text inside the indicator
+  final String Function(int index)? childText;
+
+  /// Styles the [childText]
+  final TextStyle Function(int index)? childTextStyle;
+
   @override
   State<PageViewDotIndicator> createState() => _PageViewDotIndicatorState();
 }
@@ -134,10 +142,14 @@ class _PageViewDotIndicatorState extends State<PageViewDotIndicator> {
           begin: Alignment.centerLeft,
           end: Alignment.centerRight,
           colors: <Color>[
-            widget.fadeEdges ? const Color.fromARGB(0, 255, 255, 255) : Colors.white,
+            widget.fadeEdges
+                ? const Color.fromARGB(0, 255, 255, 255)
+                : Colors.white,
             Colors.white,
             Colors.white,
-            widget.fadeEdges ? const Color.fromARGB(0, 255, 255, 255) : Colors.white,
+            widget.fadeEdges
+                ? const Color.fromARGB(0, 255, 255, 255)
+                : Colors.white,
           ],
           tileMode: TileMode.mirror,
           stops: const [0, 0.05, 0.95, 1],
@@ -164,13 +176,30 @@ class _PageViewDotIndicatorState extends State<PageViewDotIndicator> {
                 decoration: BoxDecoration(
                   borderRadius: widget.borderRadius,
                   shape: widget.boxShape,
-                  color:
-                      index == widget.currentItem ? widget.selectedColor : widget.unselectedColor,
+                  color: index == widget.currentItem
+                      ? widget.selectedColor
+                      : widget.unselectedColor,
                 ),
-                width:
-                    index == widget.currentItem ? widget.size.width : widget.unselectedSize.width,
-                height:
-                    index == widget.currentItem ? widget.size.height : widget.unselectedSize.height,
+                width: index == widget.currentItem
+                    ? widget.size.width
+                    : widget.unselectedSize.width,
+                height: index == widget.currentItem
+                    ? widget.size.height
+                    : widget.unselectedSize.height,
+                child: widget.childText != null
+                    ? Center(
+                        child: AnimatedDefaultTextStyle(
+                          duration: widget.duration,
+                          curve: Curves.easeIn,
+                          style: widget.childTextStyle != null
+                              ? widget.childTextStyle!(index)
+                              : const TextStyle(),
+                          child: Text(
+                            widget.childText!(index),
+                          ),
+                        ),
+                      )
+                    : null,
               ),
             );
           },
@@ -180,7 +209,8 @@ class _PageViewDotIndicatorState extends State<PageViewDotIndicator> {
   }
 
   double _getOffsetForCurrentPosition() {
-    final offsetPerPosition = _scrollController.position.maxScrollExtent / widget.count;
+    final offsetPerPosition =
+        _scrollController.position.maxScrollExtent / widget.count;
     final widgetOffset = widget.currentItem * offsetPerPosition;
     return widgetOffset;
   }
@@ -190,11 +220,16 @@ class _PageViewDotIndicatorState extends State<PageViewDotIndicator> {
   /// rendering all dots at once, otherwise.
   bool _needsScrolling() {
     final viewportWidth = MediaQuery.of(context).size.width;
-    final itemWidth = widget.unselectedSize.width + widget.margin.left + widget.margin.right;
-    final selectedItemWidth = widget.size.width + widget.margin.left + widget.margin.right;
+    final itemWidth =
+        widget.unselectedSize.width + widget.margin.left + widget.margin.right;
+    final selectedItemWidth =
+        widget.size.width + widget.margin.left + widget.margin.right;
     const listViewPadding = 32;
     final shaderPadding = viewportWidth * 0.1;
     return viewportWidth <
-        selectedItemWidth + (widget.count - 1) * itemWidth + listViewPadding + shaderPadding;
+        selectedItemWidth +
+            (widget.count - 1) * itemWidth +
+            listViewPadding +
+            shaderPadding;
   }
 }

--- a/lib/src/indicator.dart
+++ b/lib/src/indicator.dart
@@ -168,38 +168,40 @@ class _PageViewDotIndicatorState extends State<PageViewDotIndicator> {
           scrollDirection: Axis.horizontal,
           clipBehavior: Clip.antiAlias,
           itemBuilder: (context, index) {
-            return GestureDetector(
-              onTap: () => widget.onItemClicked?.call(index),
-              child: AnimatedContainer(
-                margin: widget.margin,
-                duration: widget.duration,
-                decoration: BoxDecoration(
-                  borderRadius: widget.borderRadius,
-                  shape: widget.boxShape,
-                  color: index == widget.currentItem
-                      ? widget.selectedColor
-                      : widget.unselectedColor,
-                ),
-                width: index == widget.currentItem
-                    ? widget.size.width
-                    : widget.unselectedSize.width,
-                height: index == widget.currentItem
-                    ? widget.size.height
-                    : widget.unselectedSize.height,
-                child: widget.childText != null
-                    ? Center(
-                        child: AnimatedDefaultTextStyle(
-                          duration: widget.duration,
-                          curve: Curves.easeIn,
-                          style: widget.childTextStyle != null
-                              ? widget.childTextStyle!(index)
-                              : const TextStyle(),
-                          child: Text(
-                            widget.childText!(index),
+            return Padding(
+              padding: widget.margin,
+              child: InkWell(
+                onTap: () => widget.onItemClicked?.call(index),
+                child: AnimatedContainer(
+                  duration: widget.duration,
+                  decoration: BoxDecoration(
+                    borderRadius: widget.borderRadius,
+                    shape: widget.boxShape,
+                    color: index == widget.currentItem
+                        ? widget.selectedColor
+                        : widget.unselectedColor,
+                  ),
+                  width: index == widget.currentItem
+                      ? widget.size.width
+                      : widget.unselectedSize.width,
+                  height: index == widget.currentItem
+                      ? widget.size.height
+                      : widget.unselectedSize.height,
+                  child: widget.childText != null
+                      ? Center(
+                          child: AnimatedDefaultTextStyle(
+                            duration: widget.duration,
+                            curve: Curves.easeIn,
+                            style: widget.childTextStyle != null
+                                ? widget.childTextStyle!(index)
+                                : const TextStyle(),
+                            child: Text(
+                              widget.childText!(index),
+                            ),
                           ),
-                        ),
-                      )
-                    : null,
+                        )
+                      : null,
+                ),
               ),
             );
           },

--- a/lib/src/indicator.dart
+++ b/lib/src/indicator.dart
@@ -130,7 +130,10 @@ class _PageViewDotIndicatorState extends State<PageViewDotIndicator> {
   }
 
   void scrollToCurrentPosition() {
-    final widgetOffset = _getOffsetForCurrentPosition();
+    final last10perc = (widget.count*0.1).ceil();
+    final widgetOffset = widget.currentItem > last10perc 
+      ? _getOffsetForCurrentPosition() + widget.size.width
+      : _getOffsetForCurrentPosition();
     _scrollController.animateTo(
       widgetOffset,
       duration: const Duration(milliseconds: 200),


### PR DESCRIPTION
New features:
- Allow text inside each page indicator. It will be, for example, the page number, or any other text. 
- Allow the list to be scrollable
- Ability to change the list axis direction

New parameters:
- ``childText``: text to input inside each page indicator
- ``childTextStyle``: you can customice the text of each page indicator
- ``scrollable``: makes the list scrollable
- ``direction``: changes the list axis direction. To allow to have vertical page indicators

Improvements:
- Improved indicators bar auto scroll position.

Example:
<img width="1312" alt="image" src="https://github.com/douglasiacovelli/page_view_dot_indicator/assets/47545344/2c730e1b-c4c2-462a-84d0-d21fc14682bd">
